### PR TITLE
fix: pyspedas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         'console_scripts': ['']
     },
     install_requires = [
-        'pyspedas'
+        'pyspedas<1.5'
     ],
     python_requires='>=3.7',
 )


### PR DESCRIPTION
Resolving the import error that occurs with versions of pyspedas 1.5 and above.

Issue: #1 